### PR TITLE
ZPL format arrives from API unencoded and should not be base64 decoded

### DIFF
--- a/lib/dhl/ecommerce/label.rb
+++ b/lib/dhl/ecommerce/label.rb
@@ -218,7 +218,7 @@ module DHL
             xml.EncodeRequest do
               xml.CustomerId location_id
               xml.BatchRef DateTime.now.strftime("%Q")
-              xml.HalfOnError false
+              xml.HaltOnError false
               xml.RejectAllOnError true
               xml.MpuList do
                 xml << labels.map do |label| label.send :xml end.join

--- a/lib/dhl/ecommerce/label.rb
+++ b/lib/dhl/ecommerce/label.rb
@@ -76,7 +76,7 @@ module DHL
       end
 
       def file
-        @base64_decoded_file ||= StringIO.new(Base64.decode64(@file))
+        @base64_decoded_file ||= StringIO.new(DHL::Ecommerce.label_format == :zpl ? @file : Base64.decode64(@file))
       end
 
       def self.create(attributes)


### PR DESCRIPTION
ZPL files were being base64 decoded when they were not encoded by DHL's API to begin with.  This change simply stops decoding when putting the raw file content into the label.file method.
