### PR TITLE
Add shipped labels to manifest to handle errors

### DIFF
--- a/lib/dhl/ecommerce/manifest.rb
+++ b/lib/dhl/ecommerce/manifest.rb
@@ -1,7 +1,7 @@
 module DHL
   module Ecommerce
     class Manifest < Base
-      attr_reader :id, :location_id
+      attr_reader :id, :location_id, :labels
 
       def location_id=(location_id)
         @location = nil
@@ -20,30 +20,55 @@ module DHL
         labels.group_by(&:location_id).each.collect do |location_id, location_labels|
           closeout_id = DHL::Ecommerce.request :get, "https://api.dhlglobalmail.com/v1/#{DHL::Ecommerce::Location.resource_name.downcase}s/#{location_id}/closeout/id"
 
-          location_labels.each_slice(500) do |slice_labels|
-            xml = Builder::XmlMarkup.new
-            xml.instruct! :xml, version: "1.1", encoding: "UTF-8"
+          shipped_labels = add_labels_to_closeout(location_id, closeout_id, location_labels)
 
-            xml.ImpbList do
-              slice_labels.each do |label|
-                xml.Impb do
-                  xml.Construct label.impb.construct
-                  xml.Value label.impb.value
-                end
+          generate_manifest(location_id, closeout_id, shipped_labels)
+        end.flatten
+      end
+
+      private
+
+      def self.add_labels_to_closeout(location_id, closeout_id, labels)
+        shipped_labels = []
+        labels.each_slice(500) do |slice_labels|
+          xml = Builder::XmlMarkup.new
+          xml.instruct! :xml, version: "1.1", encoding: "UTF-8"
+
+          xml.ImpbList do
+            slice_labels.each do |label|
+              xml.Impb do
+                xml.Construct label.impb.construct
+                xml.Value label.impb.value
               end
             end
-
-            DHL::Ecommerce.request :post, "https://api.dhlglobalmail.com/v1/#{DHL::Ecommerce::Location.resource_name.downcase}s/#{location_id}/closeout/#{closeout_id}" do |request|
-              request.body = xml.target!
-            end
           end
 
-          response = DHL::Ecommerce.request :get, "https://api.dhlglobalmail.com/v1/#{DHL::Ecommerce::Location.resource_name.downcase}s/#{location_id}/closeout/#{closeout_id}"
-          response[:manifest_list][:manifest] = [response[:manifest_list][:manifest]] unless response[:manifest_list][:manifest].is_a? Array
-          response[:manifest_list][:manifest].each.collect do |attributes|
-            new attributes.merge(location_id: location_id)
+          response_data = DHL::Ecommerce.request :post, "https://api.dhlglobalmail.com/v1/#{DHL::Ecommerce::Location.resource_name.downcase}s/#{location_id}/closeout/#{closeout_id}" do |request|
+            request.body = xml.target!
           end
-        end.flatten
+          shipped_labels << exclude_labels_with_errors(slice_labels, response_data)
+        end
+        shipped_labels.flatten
+      end
+
+      def self.generate_manifest(location_id, closeout_id, labels)
+        response = DHL::Ecommerce.request :get, "https://api.dhlglobalmail.com/v1/#{DHL::Ecommerce::Location.resource_name.downcase}s/#{location_id}/closeout/#{closeout_id}"
+        response[:manifest_list][:manifest] = [response[:manifest_list][:manifest]] unless response[:manifest_list][:manifest].is_a? Array
+        response[:manifest_list][:manifest].each.collect do |attributes|
+          new attributes.merge(location_id: location_id, labels: labels)
+        end
+      end
+
+      def self.exclude_labels_with_errors(labels, response_data)
+        if response_data.error_list
+          impb_errors = response_data.error_list.impb_error
+          impb_errors = [impb_errors] unless impb_errors.is_a? Array
+          impb_errors.each do |error|
+            labels.delete_if { |label| label.impb.value == error.impb }
+          end
+        end
+
+        labels
       end
     end
   end


### PR DESCRIPTION
When adding labels to a manifest, we can receive partially successful responses from DHL.  These changes add labels to the manifest and only appends the shipping labels that were successfully attached to the closeout.
http://api.dhlglobalmail.com/docs/closeout.html  

I'm open to alternate design approaches here, but I needed a way to differentiate between what labels were actually appended to the manifest and which failed to attach (normally because they were closed out previously).  

An alternate approach I abandoned because it seemed too obscured is to take an optional block as a parameter that is passed failed labels so the caller can decide what to do with them.  

The main downside to the way I have attached labels to the returned manifest object is that this data is not actually returned by the API.  Rather, it is constructed from the input to .create(labels).  This could lead to inconsistency in what data is present since a caller could pass any ducktyped object that has the impb construct on it to be added to the manifest.  I'm not too worried about this since the caller both injects that information and then uses it after the call, but I'm open to ways to clean it up.

Also includes a small refactor on the manifest.rb to chunk out the individual steps in the three step manifest process for clarity.
